### PR TITLE
Feat/#20 토큰 검증을 위한 ArgumentResolver 생성

### DIFF
--- a/src/main/java/coffeemeet/server/auth/RefreshTokenRepository.java
+++ b/src/main/java/coffeemeet/server/auth/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package coffeemeet.server.auth;
+
+import coffeemeet.server.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/coffeemeet/server/auth/domain/RefreshToken.java
+++ b/src/main/java/coffeemeet/server/auth/domain/RefreshToken.java
@@ -1,0 +1,23 @@
+package coffeemeet.server.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "refresh", timeToLive = 1209600)
+public class RefreshToken {
+
+  @Id
+  private Long userId;
+
+  private String value;
+
+  @Builder
+  private RefreshToken(Long userId, String value) {
+    this.userId = userId;
+    this.value = value;
+  }
+
+}

--- a/src/main/java/coffeemeet/server/certification/controller/CertificationController.java
+++ b/src/main/java/coffeemeet/server/certification/controller/CertificationController.java
@@ -3,10 +3,11 @@ package coffeemeet.server.certification.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import coffeemeet.server.certification.service.CertificationService;
+import coffeemeet.server.common.annotation.Login;
 import coffeemeet.server.common.util.FileUtils;
+import coffeemeet.server.user.dto.AuthInfo;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -21,17 +22,16 @@ public class CertificationController {
 
   private final CertificationService certificationService;
 
-  @PostMapping("/users/{userId}/business-card")
+  @PostMapping("/users/business-card")
   @ResponseStatus(CREATED)
   public void uploadBusinessCard(
-      @PathVariable("userId")
-      @NotNull(message = "유저 ID는 null일 수 없습니다.")
-      long userId,
+      @Login
+      AuthInfo authInfo,
       @RequestPart("businessCard")
       @NotNull(message = "명함 이미지는 null일 수 없습니다.")
       MultipartFile businessCard
   ) {
-    certificationService.uploadBusinessCard(userId,
+    certificationService.uploadBusinessCard(authInfo.userId(),
         FileUtils.convertMultipartFileToFile(businessCard));
   }
 

--- a/src/main/java/coffeemeet/server/common/UserArgumentResolver.java
+++ b/src/main/java/coffeemeet/server/common/UserArgumentResolver.java
@@ -1,0 +1,45 @@
+package coffeemeet.server.common;
+
+import coffeemeet.server.auth.utils.JwtTokenProvider;
+import coffeemeet.server.common.annotation.Login;
+import coffeemeet.server.user.dto.AuthInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private static final String AUTHENTICATION_FAILED_MESSAGE = "(%s)는 잘못된 권한 헤더입니다.";
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterType().equals(AuthInfo.class) && parameter.hasParameterAnnotation(
+        Login.class);
+  }
+
+  @Override
+  public AuthInfo resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+    String authHeader = httpServletRequest.getHeader("Authorization");
+
+    if (authHeader != null && authHeader.startsWith("Bearer ")) {
+      String token = authHeader.substring(7);
+      Long userId = jwtTokenProvider.extractUserId(token);
+      return new AuthInfo(userId, token);
+    }
+    throw new IllegalArgumentException(
+        String.format(AUTHENTICATION_FAILED_MESSAGE, authHeader)
+    );
+  }
+
+}

--- a/src/main/java/coffeemeet/server/common/UserArgumentResolver.java
+++ b/src/main/java/coffeemeet/server/common/UserArgumentResolver.java
@@ -18,8 +18,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class UserArgumentResolver implements HandlerMethodArgumentResolver {
 
-  private static final String HEADER_AUTHENTICATION_FAILED_MESSAGE = "(%s)는 잘못된 권한 헤더입니다.";
   public static final String USER_AUTHENTICATION_FAILED_MESSAGE = "사용자(%s)의 갱신 토큰이 존재하지 않습니다.";
+  private static final String HEADER_AUTHENTICATION_FAILED_MESSAGE = "(%s)는 잘못된 권한 헤더입니다.";
 
   private final JwtTokenProvider jwtTokenProvider;
   private final RefreshTokenRepository refreshTokenRepository;

--- a/src/main/java/coffeemeet/server/common/annotation/Login.java
+++ b/src/main/java/coffeemeet/server/common/annotation/Login.java
@@ -1,0 +1,12 @@
+package coffeemeet.server.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+
+}

--- a/src/main/java/coffeemeet/server/common/config/AuthWebConfig.java
+++ b/src/main/java/coffeemeet/server/common/config/AuthWebConfig.java
@@ -2,9 +2,12 @@ package coffeemeet.server.common.config;
 
 import coffeemeet.server.auth.utils.JwtTokenProvider;
 import coffeemeet.server.auth.utils.converter.OAuthProviderConverter;
+import coffeemeet.server.common.UserArgumentResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -16,6 +19,11 @@ public class AuthWebConfig implements WebMvcConfigurer {
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new OAuthProviderConverter());
+  }
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new UserArgumentResolver(jwtTokenProvider));
   }
 
 }

--- a/src/main/java/coffeemeet/server/common/config/AuthWebConfig.java
+++ b/src/main/java/coffeemeet/server/common/config/AuthWebConfig.java
@@ -1,5 +1,6 @@
 package coffeemeet.server.common.config;
 
+import coffeemeet.server.auth.RefreshTokenRepository;
 import coffeemeet.server.auth.utils.JwtTokenProvider;
 import coffeemeet.server.auth.utils.converter.OAuthProviderConverter;
 import coffeemeet.server.common.UserArgumentResolver;
@@ -15,6 +16,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class AuthWebConfig implements WebMvcConfigurer {
 
   private final JwtTokenProvider jwtTokenProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @Override
   public void addFormatters(FormatterRegistry registry) {
@@ -23,7 +25,7 @@ public class AuthWebConfig implements WebMvcConfigurer {
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-    resolvers.add(new UserArgumentResolver(jwtTokenProvider));
+    resolvers.add(new UserArgumentResolver(jwtTokenProvider, refreshTokenRepository));
   }
 
 }

--- a/src/main/java/coffeemeet/server/common/util/FileUtils.java
+++ b/src/main/java/coffeemeet/server/common/util/FileUtils.java
@@ -13,14 +13,6 @@ public final class FileUtils {
   private static final String MULTIPART_FILE_TRANSFER_ERROR = "MULTIPART FILE을 FILE로 변환 중 오류가 발생했습니다.";
   private static final String FILE_DELETE_ERROR = "FILE 삭제 중 오류가 발생했습니다.";
 
-  public static class FileIOException extends RuntimeException {
-
-    public FileIOException(String message, Throwable e) {
-      super(message, e);
-    }
-
-  }
-
   public static File convertMultipartFileToFile(MultipartFile multipartFile) {
     try {
       File file = File.createTempFile("temp", multipartFile.getOriginalFilename());
@@ -37,6 +29,14 @@ public final class FileUtils {
     } catch (IOException e) {
       throw new FileIOException(FILE_DELETE_ERROR, e);
     }
+  }
+
+  public static class FileIOException extends RuntimeException {
+
+    public FileIOException(String message, Throwable e) {
+      super(message, e);
+    }
+
   }
 
 }

--- a/src/main/java/coffeemeet/server/user/dto/AuthInfo.java
+++ b/src/main/java/coffeemeet/server/user/dto/AuthInfo.java
@@ -1,0 +1,4 @@
+package coffeemeet.server.user.dto;
+
+public record AuthInfo(Long userId, String refreshToken) {
+}

--- a/src/main/java/coffeemeet/server/user/dto/AuthInfo.java
+++ b/src/main/java/coffeemeet/server/user/dto/AuthInfo.java
@@ -1,4 +1,5 @@
 package coffeemeet.server.user.dto;
 
 public record AuthInfo(Long userId, String refreshToken) {
+
 }

--- a/src/test/java/coffeemeet/server/common/config/ControllerTestConfig.java
+++ b/src/test/java/coffeemeet/server/common/config/ControllerTestConfig.java
@@ -3,6 +3,7 @@ package coffeemeet.server.common.config;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
+import coffeemeet.server.auth.RefreshTokenRepository;
 import coffeemeet.server.auth.utils.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,9 @@ public abstract class ControllerTestConfig {
 
   @MockBean
   protected JwtTokenProvider jwtTokenProvider;
+
+  @MockBean
+  protected RefreshTokenRepository refreshTokenRepository;
 
   @BeforeEach
   void setUp(WebApplicationContext ctx, RestDocumentationContextProvider restDocumentation) {


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #20

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- [x] UserArgumentResolver 생성
- [x] @Login 어노테이션 생성
- [x] redis, RefreshToken 해시 생성
- [x] redis, RefreshTokenRepository 저장소 생성
## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
- 사용자의 인증은 @Login과 AuthInfo 객체를 통해 인증됩니다.
  - UserArgumentResolver에 의해 userId와 refreshToken을 AuthInfo 객체에 담아 전달
- 추가적으로 명함 업로드 uri 수정 및 로직 변경 