### PR TITLE
Feat/#26 인증 토큰 갱신 기능 구현

### DIFF
--- a/src/main/java/coffeemeet/server/auth/controller/AuthController.java
+++ b/src/main/java/coffeemeet/server/auth/controller/AuthController.java
@@ -3,7 +3,9 @@ package coffeemeet.server.auth.controller;
 import coffeemeet.server.auth.dto.SignupRequest;
 import coffeemeet.server.auth.service.AuthService;
 import coffeemeet.server.auth.utils.AuthTokens;
+import coffeemeet.server.common.annotation.Login;
 import coffeemeet.server.user.domain.OAuthProvider;
+import coffeemeet.server.user.dto.AuthInfo;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -42,6 +44,11 @@ public class AuthController {
   public ResponseEntity<AuthTokens> login(@PathVariable OAuthProvider oAuthProvider,
       @RequestParam String authCode) {
     return ResponseEntity.ok(authService.login(oAuthProvider, authCode));
+  }
+
+  @PostMapping("/renew-token")
+  public ResponseEntity<AuthTokens> renew(@Login AuthInfo authInfo) {
+    return ResponseEntity.ok(authService.renew(authInfo.userId(), authInfo.refreshToken()));
   }
 
 }

--- a/src/main/java/coffeemeet/server/auth/controller/AuthController.java
+++ b/src/main/java/coffeemeet/server/auth/controller/AuthController.java
@@ -5,8 +5,8 @@ import coffeemeet.server.auth.service.AuthService;
 import coffeemeet.server.auth.utils.AuthTokens;
 import coffeemeet.server.user.domain.OAuthProvider;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import java.io.IOException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,21 +34,14 @@ public class AuthController {
   }
 
   @PostMapping("/sign-up")
-  public ResponseEntity<AuthTokens> signup(@RequestBody SignupRequest request) {
+  public ResponseEntity<AuthTokens> signup(@Valid @RequestBody SignupRequest request) {
     return ResponseEntity.ok(authService.signup(request));
   }
 
   @GetMapping("/login/{oAuthProvider}")
-  public ResponseEntity<?> login(@PathVariable OAuthProvider oAuthProvider,
-      @RequestParam String authCode, HttpServletResponse response) throws IOException {
-    Optional<AuthTokens> authTokens = authService.login(oAuthProvider, authCode);
-    if (authTokens.isPresent()) {
-      return ResponseEntity.ok(authTokens.get());
-    }
-
-    String signupUrl = "/oauth2/auth/sign-up";
-    response.sendRedirect(signupUrl);
-    return new ResponseEntity<>(HttpStatus.FOUND);
+  public ResponseEntity<AuthTokens> login(@PathVariable OAuthProvider oAuthProvider,
+      @RequestParam String authCode) {
+    return ResponseEntity.ok(authService.login(oAuthProvider, authCode));
   }
 
 }

--- a/src/main/java/coffeemeet/server/auth/dto/SignupRequest.java
+++ b/src/main/java/coffeemeet/server/auth/dto/SignupRequest.java
@@ -2,27 +2,18 @@ package coffeemeet.server.auth.dto;
 
 import coffeemeet.server.interest.domain.Keyword;
 import coffeemeet.server.user.domain.OAuthProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record SignupRequest(
+    @NotBlank
     String nickname,
+    @NotNull
     List<Keyword> keywords,
+    @NotBlank
     String authCode,
     OAuthProvider oAuthProvider
 ) {
-
-  public static SignupRequest of(
-      String nickname,
-      List<Keyword> keywords,
-      String authCode,
-      OAuthProvider oAuthProvider
-  ) {
-    return new SignupRequest(
-        nickname,
-        keywords,
-        authCode,
-        oAuthProvider
-    );
-  }
 
 }

--- a/src/main/java/coffeemeet/server/auth/utils/AuthTokensGenerator.java
+++ b/src/main/java/coffeemeet/server/auth/utils/AuthTokensGenerator.java
@@ -47,7 +47,7 @@ public class AuthTokensGenerator {
     );
   }
 
-  public AuthTokens refreshJwtToken(Long userId, String refreshToken) {
+  public AuthTokens reissueAccessToken(Long userId, String refreshToken) {
     long now = (new Date()).getTime();
     Date accessTokenExpiredAt = new Date(now + accessTokenExpireTime);
 


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #26 

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- [x] 인증 토큰 갱신 기능 구현 
## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->
- 로그인 API 수정 
  - 회원가입 API 요청 데이터 검증 추가
  - 로그인 안될 시, 회원가입 API 리다이렉트 하는부분 제거
- 토큰 갱신 API 작성
  - 액세스 토큰이 만료 되면, 리프레시 토큰을 통해 액세스 토큰 재발급
  - 리프레시 토큰도 만료 되면 예외 발생