### PR TITLE
Feat/#114 관리자 로그인, 인증 수락 / 반려, 신고 승인 / 거부 구현

### DIFF
--- a/src/main/java/coffeemeet/server/admin/domain/Admin.java
+++ b/src/main/java/coffeemeet/server/admin/domain/Admin.java
@@ -22,4 +22,8 @@ public class Admin extends BaseEntity {
   @Column(nullable = false)
   private String password;
 
+  public boolean isCorrectPassword(String password) {
+    return this.password.equals(password);
+  }
+
 }

--- a/src/main/java/coffeemeet/server/admin/exception/AdminErrorCode.java
+++ b/src/main/java/coffeemeet/server/admin/exception/AdminErrorCode.java
@@ -1,0 +1,26 @@
+package coffeemeet.server.admin.exception;
+
+import coffeemeet.server.common.execption.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements ErrorCode {
+  INVALID_LOGIN_REQUEST("A001", "잘못된 아이디 비밀번호 입니다."),
+  NOT_AUTHORIZED("A001", "해당 요청에 대한 권한이 없습니다.");
+
+  private final String errorCode;
+  private final String message;
+
+  @Override
+  public String code() {
+    return errorCode;
+  }
+
+  @Override
+  public String message() {
+    return message;
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/implement/AdminQuery.java
+++ b/src/main/java/coffeemeet/server/admin/implement/AdminQuery.java
@@ -1,0 +1,30 @@
+package coffeemeet.server.admin.implement;
+
+
+import static coffeemeet.server.common.execption.GlobalErrorCode.VALIDATION_ERROR;
+
+import coffeemeet.server.admin.domain.Admin;
+import coffeemeet.server.admin.infrastructure.AdminRepository;
+import coffeemeet.server.common.execption.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminQuery {
+
+  private final AdminRepository adminRepository;
+
+  public void checkIdAndPassword(String id, String password) {
+    Admin admin = adminRepository.findById(id)
+        .orElseThrow(() -> new NotFoundException(VALIDATION_ERROR,
+            String.format("유효하지 않은 관리자 아이디(%s)입니다.", id)));
+
+    if (admin.isCorrectPassword(password)) {
+      return;
+    }
+    throw new NotFoundException(VALIDATION_ERROR,
+        String.format("유효하지 않은 관리자 비밀번호(%s)입니다.", password));
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/infrastructure/AdminRepository.java
+++ b/src/main/java/coffeemeet/server/admin/infrastructure/AdminRepository.java
@@ -1,0 +1,8 @@
+package coffeemeet.server.admin.infrastructure;
+
+import coffeemeet.server.admin.domain.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, String> {
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
@@ -2,6 +2,7 @@ package coffeemeet.server.admin.presentation;
 
 import static coffeemeet.server.admin.exception.AdminErrorCode.NOT_AUTHORIZED;
 
+import coffeemeet.server.admin.presentation.dto.AdminLoginHTTP;
 import coffeemeet.server.admin.presentation.dto.CertificationApprovalHTTP;
 import coffeemeet.server.admin.presentation.dto.CertificationRejectionHTTP;
 import coffeemeet.server.admin.presentation.dto.ReportApprovalHTTP;
@@ -10,6 +11,7 @@ import coffeemeet.server.admin.service.AdminService;
 import coffeemeet.server.common.execption.InvalidAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,7 +33,7 @@ public class AdminController {
   @PostMapping("/login")
   public ResponseEntity<Void> login(
       HttpServletRequest httpServletRequest,
-      @RequestBody AdminLoginHTTP.Request request
+      @Valid @RequestBody AdminLoginHTTP.Request request
   ) {
     adminService.login(request.id(), request.password());
 
@@ -55,7 +57,7 @@ public class AdminController {
   @PatchMapping("/certification/approval")
   public ResponseEntity<Void> approveCertification(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
-      @RequestBody CertificationApprovalHTTP.Request request) {
+      @Valid @RequestBody CertificationApprovalHTTP.Request request) {
     if (adminId == null) {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
     }
@@ -66,7 +68,7 @@ public class AdminController {
   @PatchMapping("/certification/rejection")
   public ResponseEntity<Void> rejectCertification(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
-      @RequestBody CertificationRejectionHTTP.Request request
+      @Valid @RequestBody CertificationRejectionHTTP.Request request
   ) {
     if (adminId == null) {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
@@ -78,7 +80,7 @@ public class AdminController {
   @PatchMapping("/report/punishment")
   public ResponseEntity<Void> assignReportPenalty(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
-      @RequestBody ReportApprovalHTTP.Request request
+      @Valid @RequestBody ReportApprovalHTTP.Request request
   ) {
     if (adminId == null) {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
@@ -90,7 +92,7 @@ public class AdminController {
   @PatchMapping("/report/rejection")
   public ResponseEntity<Void> dismissReport(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
-      @RequestBody ReportRejectionHTTP.Request request
+      @Valid @RequestBody ReportRejectionHTTP.Request request
   ) {
     if (adminId == null) {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);

--- a/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
@@ -11,6 +11,7 @@ import coffeemeet.server.common.execption.InvalidAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,12 +24,12 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 @RequestMapping("/api/v1/admin")
 public class AdminController {
 
-  public static final String REQUEST_WITHOUT_SESSION_MESSAGE = "SESSION 값이 존재하지 않습니다.";
-  public static final String ADMIN_ID = "adminId";
+  private static final String REQUEST_WITHOUT_SESSION_MESSAGE = "SESSION 값이 존재하지 않습니다.";
+  private static final String ADMIN_ID = "adminId";
   private final AdminService adminService;
 
   @PostMapping("/login")
-  public void login(
+  public ResponseEntity<Void> login(
       HttpServletRequest httpServletRequest,
       @RequestBody AdminLoginHTTP.Request request
   ) {
@@ -37,30 +38,33 @@ public class AdminController {
     HttpSession session = httpServletRequest.getSession();
     session.setAttribute(ADMIN_ID, request.id());
     session.setMaxInactiveInterval(1800);
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/logout")
-  public void logout(
+  public ResponseEntity<Void> logout(
       HttpServletRequest httpServletRequest
   ) {
     HttpSession session = httpServletRequest.getSession(false);
     if (session != null) {
       session.invalidate();
     }
+    return ResponseEntity.ok().build();
   }
 
   @PatchMapping("/certification/approval")
-  public void approveCertification(
+  public ResponseEntity<Void> approveCertification(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
       @RequestBody CertificationApprovalHTTP.Request request) {
     if (adminId == null) {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
     }
     adminService.approveCertification(request.userId());
+    return ResponseEntity.ok().build();
   }
 
   @PatchMapping("/certification/rejection")
-  public void rejectCertification(
+  public ResponseEntity<Void> rejectCertification(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
       @RequestBody CertificationRejectionHTTP.Request request
   ) {
@@ -68,10 +72,11 @@ public class AdminController {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
     }
     adminService.rejectCertification(request.userId());
+    return ResponseEntity.ok().build();
   }
 
   @PatchMapping("/report/punishment")
-  public void assignReportPenalty(
+  public ResponseEntity<Void> assignReportPenalty(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
       @RequestBody ReportApprovalHTTP.Request request
   ) {
@@ -79,10 +84,11 @@ public class AdminController {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
     }
     adminService.punishUser(request.reportId(), request.userId());
+    return ResponseEntity.ok().build();
   }
 
   @PatchMapping("/report/rejection")
-  public void dismissReport(
+  public ResponseEntity<Void> dismissReport(
       @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
       @RequestBody ReportRejectionHTTP.Request request
   ) {
@@ -90,6 +96,7 @@ public class AdminController {
       throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
     }
     adminService.dismissReport(request.reportId());
+    return ResponseEntity.ok().build();
   }
 
 }

--- a/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
@@ -1,0 +1,41 @@
+package coffeemeet.server.admin.presentation;
+
+import coffeemeet.server.admin.presentation.dto.CertificationApprovalHTTP;
+import coffeemeet.server.admin.presentation.dto.CertificationRejectionHTTP;
+import coffeemeet.server.admin.presentation.dto.ReportApprovalHTTP;
+import coffeemeet.server.admin.presentation.dto.ReportRejectionHTTP;
+import coffeemeet.server.admin.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminController {
+
+  private final AdminService adminService;
+
+  @PatchMapping("/certification/approval")
+  public void approveCertification(@RequestBody CertificationApprovalHTTP.Request request) {
+    adminService.approveCertification(request.userId());
+  }
+
+  @PatchMapping("/certification/rejection")
+  public void rejectCertification(@RequestBody CertificationRejectionHTTP.Request request) {
+    adminService.rejectCertification(request.userId());
+  }
+
+  @PatchMapping("/report/punishment")
+  public void assignReportPenalty(@RequestBody ReportApprovalHTTP.Request request) {
+    adminService.punishUser(request.reportId(), request.userId());
+  }
+
+  @PatchMapping("/report/rejection")
+  public void dismissReport(@RequestBody ReportRejectionHTTP.Request request) {
+    adminService.dismissReport(request.reportId());
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/AdminController.java
@@ -1,40 +1,94 @@
 package coffeemeet.server.admin.presentation;
 
+import static coffeemeet.server.admin.exception.AdminErrorCode.NOT_AUTHORIZED;
+
 import coffeemeet.server.admin.presentation.dto.CertificationApprovalHTTP;
 import coffeemeet.server.admin.presentation.dto.CertificationRejectionHTTP;
 import coffeemeet.server.admin.presentation.dto.ReportApprovalHTTP;
 import coffeemeet.server.admin.presentation.dto.ReportRejectionHTTP;
 import coffeemeet.server.admin.service.AdminService;
+import coffeemeet.server.common.execption.InvalidAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttribute;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin")
 public class AdminController {
 
+  public static final String REQUEST_WITHOUT_SESSION_MESSAGE = "SESSION 값이 존재하지 않습니다.";
+  public static final String ADMIN_ID = "adminId";
   private final AdminService adminService;
 
+  @PostMapping("/login")
+  public void login(
+      HttpServletRequest httpServletRequest,
+      @RequestBody AdminLoginHTTP.Request request
+  ) {
+    adminService.login(request.id(), request.password());
+
+    HttpSession session = httpServletRequest.getSession();
+    session.setAttribute(ADMIN_ID, request.id());
+    session.setMaxInactiveInterval(1800);
+  }
+
+  @PostMapping("/logout")
+  public void logout(
+      HttpServletRequest httpServletRequest
+  ) {
+    HttpSession session = httpServletRequest.getSession(false);
+    if (session != null) {
+      session.invalidate();
+    }
+  }
+
   @PatchMapping("/certification/approval")
-  public void approveCertification(@RequestBody CertificationApprovalHTTP.Request request) {
+  public void approveCertification(
+      @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
+      @RequestBody CertificationApprovalHTTP.Request request) {
+    if (adminId == null) {
+      throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
+    }
     adminService.approveCertification(request.userId());
   }
 
   @PatchMapping("/certification/rejection")
-  public void rejectCertification(@RequestBody CertificationRejectionHTTP.Request request) {
+  public void rejectCertification(
+      @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
+      @RequestBody CertificationRejectionHTTP.Request request
+  ) {
+    if (adminId == null) {
+      throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
+    }
     adminService.rejectCertification(request.userId());
   }
 
   @PatchMapping("/report/punishment")
-  public void assignReportPenalty(@RequestBody ReportApprovalHTTP.Request request) {
+  public void assignReportPenalty(
+      @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
+      @RequestBody ReportApprovalHTTP.Request request
+  ) {
+    if (adminId == null) {
+      throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
+    }
     adminService.punishUser(request.reportId(), request.userId());
   }
 
   @PatchMapping("/report/rejection")
-  public void dismissReport(@RequestBody ReportRejectionHTTP.Request request) {
+  public void dismissReport(
+      @SessionAttribute(name = ADMIN_ID, required = false) String adminId,
+      @RequestBody ReportRejectionHTTP.Request request
+  ) {
+    if (adminId == null) {
+      throw new InvalidAuthException(NOT_AUTHORIZED, REQUEST_WITHOUT_SESSION_MESSAGE);
+    }
     adminService.dismissReport(request.reportId());
   }
 

--- a/src/main/java/coffeemeet/server/admin/presentation/AdminLoginHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/AdminLoginHTTP.java
@@ -1,0 +1,12 @@
+package coffeemeet.server.admin.presentation;
+
+public sealed interface AdminLoginHTTP permits AdminLoginHTTP.Request {
+
+  record Request(
+      String id,
+      String password
+  ) implements AdminLoginHTTP {
+
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/AdminLoginHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/AdminLoginHTTP.java
@@ -1,9 +1,13 @@
-package coffeemeet.server.admin.presentation;
+package coffeemeet.server.admin.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
 
 public sealed interface AdminLoginHTTP permits AdminLoginHTTP.Request {
 
   record Request(
+      @NotBlank
       String id,
+      @NotBlank
       String password
   ) implements AdminLoginHTTP {
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
@@ -1,8 +1,11 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public sealed interface CertificationApprovalHTTP permits CertificationApprovalHTTP.Request {
 
   record Request(
+      @NotNull
       Long userId
   ) implements CertificationApprovalHTTP {
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
@@ -1,0 +1,11 @@
+package coffeemeet.server.admin.presentation.dto;
+
+public sealed interface CertificationApprovalHTTP permits CertificationApprovalHTTP.Request {
+
+  record Request(
+      Long userId
+  ) implements CertificationApprovalHTTP {
+
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
@@ -1,0 +1,11 @@
+package coffeemeet.server.admin.presentation.dto;
+
+public sealed interface CertificationRejectionHTTP permits CertificationRejectionHTTP.Request {
+
+  record Request(
+      Long userId
+  ) implements CertificationRejectionHTTP {
+
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
@@ -1,8 +1,11 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public sealed interface CertificationRejectionHTTP permits CertificationRejectionHTTP.Request {
 
   record Request(
+      @NotNull
       Long userId
   ) implements CertificationRejectionHTTP {
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
@@ -1,0 +1,12 @@
+package coffeemeet.server.admin.presentation.dto;
+
+public sealed interface ReportApprovalHTTP permits ReportApprovalHTTP.Request {
+
+  record Request(
+      Long reportId,
+      Long userId
+  ) implements ReportApprovalHTTP {
+
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
@@ -1,9 +1,13 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public sealed interface ReportApprovalHTTP permits ReportApprovalHTTP.Request {
 
   record Request(
+      @NotNull
       Long reportId,
+      @NotNull
       Long userId
   ) implements ReportApprovalHTTP {
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
@@ -1,8 +1,11 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public sealed interface ReportRejectionHTTP permits ReportRejectionHTTP.Request {
 
   record Request(
+      @NotNull
       Long reportId
   ) implements ReportRejectionHTTP {
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
@@ -1,0 +1,11 @@
+package coffeemeet.server.admin.presentation.dto;
+
+public sealed interface ReportRejectionHTTP permits ReportRejectionHTTP.Request {
+
+  record Request(
+      Long reportId
+  ) implements ReportRejectionHTTP {
+
+  }
+
+}

--- a/src/main/java/coffeemeet/server/admin/service/AdminService.java
+++ b/src/main/java/coffeemeet/server/admin/service/AdminService.java
@@ -2,6 +2,7 @@ package coffeemeet.server.admin.service;
 
 import static coffeemeet.server.user.domain.UserStatus.MATCHING;
 
+import coffeemeet.server.admin.implement.AdminQuery;
 import coffeemeet.server.certification.implement.CertificationCommand;
 import coffeemeet.server.certification.implement.CertificationQuery;
 import coffeemeet.server.common.implement.FCMNotificationSender;
@@ -24,6 +25,11 @@ public class AdminService {
   private final ReportCommand reportCommand;
   private final MatchingQueueCommand matchingQueueCommand;
   private final CertificationQuery certificationQuery;
+  private final AdminQuery adminQuery;
+
+  public void login(String id, String password) {
+    adminQuery.checkIdAndPassword(id, password);
+  }
 
   public void approveCertification(Long userId) {
     certificationCommand.certificated(userId);

--- a/src/main/java/coffeemeet/server/admin/service/AdminService.java
+++ b/src/main/java/coffeemeet/server/admin/service/AdminService.java
@@ -1,0 +1,61 @@
+package coffeemeet.server.admin.service;
+
+import static coffeemeet.server.user.domain.UserStatus.MATCHING;
+
+import coffeemeet.server.certification.implement.CertificationCommand;
+import coffeemeet.server.certification.implement.CertificationQuery;
+import coffeemeet.server.common.implement.FCMNotificationSender;
+import coffeemeet.server.matching.implement.MatchingQueueCommand;
+import coffeemeet.server.report.implement.ReportCommand;
+import coffeemeet.server.user.domain.NotificationInfo;
+import coffeemeet.server.user.domain.User;
+import coffeemeet.server.user.implement.UserQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+  private final CertificationCommand certificationCommand;
+  private final UserQuery userQuery;
+  private final FCMNotificationSender fcmNotificationSender;
+  private final ReportCommand reportCommand;
+  private final MatchingQueueCommand matchingQueueCommand;
+  private final CertificationQuery certificationQuery;
+
+  public void approveCertification(Long userId) {
+    certificationCommand.certificated(userId);
+
+    NotificationInfo notificationInfo = userQuery.getNotificationInfoByUserId(userId);
+    fcmNotificationSender.sendNotification(notificationInfo,
+        "축하드립니다! 회사 인증이 완료됐습니다. 이제부터 모든 서비스를 자유롭게 이용하실 수 있습니다.");
+  }
+
+  public void rejectCertification(Long userId) {
+    certificationCommand.deleteUserCertification(userId);
+
+    NotificationInfo notificationInfo = userQuery.getNotificationInfoByUserId(userId);
+    fcmNotificationSender.sendNotification(notificationInfo, "규정 및 기준에 부합하지 않아 회사 인증이 반려되었습니다.");
+  }
+
+  @Transactional  // TODO: 2023/11/17 추후 구조 변경을 통해서 개선 예정
+  public void punishUser(Long reportId, Long userId) {
+    User user = userQuery.getUserById(userId);
+    if (user.getUserStatus() == MATCHING) {
+      String companyName = certificationQuery.getCompanyNameByUserId(userId);
+      matchingQueueCommand.deleteUserByUserId(companyName, userId);
+    }
+    user.punished();
+
+    reportCommand.processReport(reportId);
+    fcmNotificationSender.sendNotification(user.getNotificationInfo(),
+        "귀하의 계정은 최근 신고 접수로 인해 일시적으로 서비스 이용이 제한되었습니다.");
+  }
+
+  public void dismissReport(Long reportId) {
+    reportCommand.processReport(reportId);
+  }
+
+}

--- a/src/main/java/coffeemeet/server/certification/domain/Certification.java
+++ b/src/main/java/coffeemeet/server/certification/domain/Certification.java
@@ -42,6 +42,7 @@ public class Certification extends AdvancedBaseEntity {
   private String businessCardUrl;
 
   @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
   private Department department;
 
   @Column(nullable = false)
@@ -57,6 +58,10 @@ public class Certification extends AdvancedBaseEntity {
     this.department = department;
     this.isCertificated = false;
     this.user = user;
+  }
+
+  public void qualify() {
+    isCertificated = true;
   }
 
 }

--- a/src/main/java/coffeemeet/server/certification/domain/CompanyEmail.java
+++ b/src/main/java/coffeemeet/server/certification/domain/CompanyEmail.java
@@ -12,7 +12,7 @@ import lombok.NonNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompanyEmail {
 
-  @Column(name = "company_email")
+  @Column(name = "company_email", nullable = false)
   private String value;
 
   public CompanyEmail(@NonNull String value) {

--- a/src/main/java/coffeemeet/server/certification/implement/CertificationCommand.java
+++ b/src/main/java/coffeemeet/server/certification/implement/CertificationCommand.java
@@ -21,6 +21,7 @@ public class CertificationCommand {
   private static final String EXISTED_COMPANY_EMAIL_MESSAGE = "이미 사용 중인 회사 이메일(%s) 입니다.";
 
   private final CertificationRepository certificationRepository;
+  private final CertificationQuery certificationQuery;
 
   public void createCertification(User user, String companyName, CompanyEmail companyEmail,
       Department department, String businessCardUrl) {
@@ -42,8 +43,18 @@ public class CertificationCommand {
     }
   }
 
+  public void certificated(Long userId) {
+    Certification certification = certificationQuery.getCertificationByUserId(userId);
+    certification.qualify();
+  }
+
+  @Transactional(readOnly = true)
   public void applyIfCertifiedUser(Long userId, Consumer<? super Certification> consumer) {
     certificationRepository.findByUserId(userId).ifPresent(consumer);
+  }
+
+  public void deleteUserCertification(Long userId) {
+    certificationRepository.deleteById(userId);
   }
 
 }

--- a/src/main/java/coffeemeet/server/chatting/current/service/ChattingRoomService.java
+++ b/src/main/java/coffeemeet/server/chatting/current/service/ChattingRoomService.java
@@ -74,7 +74,7 @@ public class ChattingRoomService {
   }
 
   private void updateUserStatusToIdle(List<User> users) {
-    users.forEach(User::setIdleState);
+    users.forEach(User::setIdleStatus);
   }
 
 }

--- a/src/main/java/coffeemeet/server/common/execption/LimitExceededException.java
+++ b/src/main/java/coffeemeet/server/common/execption/LimitExceededException.java
@@ -1,0 +1,14 @@
+package coffeemeet.server.common.execption;
+
+import lombok.Getter;
+
+@Getter
+public class LimitExceededException extends CoffeeMeetException {
+
+  private final ErrorCode errorCode;
+
+  public LimitExceededException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/coffeemeet/server/common/execption/RedisException.java
+++ b/src/main/java/coffeemeet/server/common/execption/RedisException.java
@@ -7,7 +7,7 @@ public class RedisException extends CoffeeMeetException {
 
   private final ErrorCode errorCode;
 
-  public RedisException(String message, ErrorCode errorCode) {
+  public RedisException(ErrorCode errorCode, String message) {
     super(message);
     this.errorCode = errorCode;
   }

--- a/src/main/java/coffeemeet/server/matching/implement/MatchingQueueCommand.java
+++ b/src/main/java/coffeemeet/server/matching/implement/MatchingQueueCommand.java
@@ -22,4 +22,8 @@ public class MatchingQueueCommand {
     }
   }
 
+  public void deleteUserByUserId(String companyName,Long userId) {
+    redisTemplate.opsForZSet().remove(companyName, userId);
+  }
+
 }

--- a/src/main/java/coffeemeet/server/matching/implement/MatchingQueueCommand.java
+++ b/src/main/java/coffeemeet/server/matching/implement/MatchingQueueCommand.java
@@ -18,7 +18,7 @@ public class MatchingQueueCommand {
     ZSetOperations<String, Long> zSetOperations = redisTemplate.opsForZSet();
     Boolean result = zSetOperations.add(companyName, userId, System.currentTimeMillis());
     if (result == null) {
-      throw new RedisException("Redis가 Pipeline 상태이거나 Transaction 상태입니다.", INTERNAL_SERVER_ERROR);
+      throw new RedisException(INTERNAL_SERVER_ERROR, "Redis가 Pipeline 상태이거나 Transaction 상태입니다.");
     }
   }
 

--- a/src/main/java/coffeemeet/server/report/domain/Report.java
+++ b/src/main/java/coffeemeet/server/report/domain/Report.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import org.springframework.util.StringUtils;
 
 @Entity
@@ -38,33 +39,23 @@ public class Report extends BaseEntity {
   @Column(nullable = false, length = REASON_MAX_LENGTH)
   private String reason;
 
+  @Column(nullable = false)
+  private boolean isProcessed;
+
   @Builder
   private Report(
-      Long reporterId,
-      Long targetId,
-      String title,
-      String reason
+      @NonNull Long reporterId,
+      @NonNull Long targetId,
+      @NonNull String title,
+      @NonNull String reason
   ) {
-    validateReporter(reporterId);
-    validateTarget(targetId);
     validateTitle(title);
     validateReason(reason);
     this.reporterId = reporterId;
     this.targetId = targetId;
     this.title = title;
     this.reason = reason;
-  }
-
-  private void validateReporter(Long reporterId) {
-    if (reporterId == null) {
-      throw new IllegalArgumentException("올바르지 않은 사용자(리포터) 아이디입니다.");
-    }
-  }
-
-  private void validateTarget(Long targetId) {
-    if (targetId == null) {
-      throw new IllegalArgumentException("올바르지 않은 사용자(타켓) 아이디입니다.");
-    }
+    isProcessed = false;
   }
 
   private void validateTitle(String title) {
@@ -77,6 +68,9 @@ public class Report extends BaseEntity {
     if (!StringUtils.hasText(reason) || reason.length() > REASON_MAX_LENGTH) {
       throw new IllegalArgumentException("올바르지 않은 사유입니다.");
     }
+  }
+  public void processed() {
+    isProcessed = true;
   }
 
 }

--- a/src/main/java/coffeemeet/server/report/domain/ReportPenalty.java
+++ b/src/main/java/coffeemeet/server/report/domain/ReportPenalty.java
@@ -1,0 +1,30 @@
+package coffeemeet.server.report.domain;
+
+import coffeemeet.server.common.execption.CoffeeMeetException;
+import lombok.Getter;
+
+@Getter
+public enum ReportPenalty {
+  ONE_TIME(1,3),
+  TWO_TIMES(2, 7),
+  THREE_TIMES(3, 15),
+  FOUR_TIMES(4, 30),
+  FIVE_TIMES(5, -1); // -1은 영구 정지를 의미합니다.
+
+  private final int reportCount;
+  private final int penaltyDuration;
+
+  ReportPenalty(int reportCount, int penaltyDuration) {
+    this.reportCount = reportCount;
+    this.penaltyDuration = penaltyDuration;
+  }
+
+  public static int getSanctionPeriodByReportCount(int reportCount) {
+    for (ReportPenalty penalty : ReportPenalty.values()) {
+      if (penalty.getReportCount() == reportCount) {
+        return penalty.getPenaltyDuration();
+      }
+    }
+    throw new CoffeeMeetException(String.format("잘못된 신고 횟수(%s) 입니다.", reportCount));
+  }
+}

--- a/src/main/java/coffeemeet/server/report/exception/ReportErrorCode.java
+++ b/src/main/java/coffeemeet/server/report/exception/ReportErrorCode.java
@@ -1,0 +1,24 @@
+package coffeemeet.server.report.exception;
+
+import coffeemeet.server.common.execption.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+  EXCEEDED_MAX_REPORT_COUNT("R000", "이미 영구 정지된 사용자입니다."),
+  REPORT_NOT_FOUND("R004", "해당 신고 정보를 찾을 수가 없습니다.")
+  ;
+
+  private final String errorCode;
+  private final String message;
+
+  @Override
+  public String code() {
+    return errorCode;
+  }
+
+  @Override
+  public String message() {
+    return message;
+  }
+}

--- a/src/main/java/coffeemeet/server/report/implement/ReportCommand.java
+++ b/src/main/java/coffeemeet/server/report/implement/ReportCommand.java
@@ -1,0 +1,20 @@
+package coffeemeet.server.report.implement;
+
+import coffeemeet.server.report.domain.Report;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ReportCommand {
+
+  private final ReportQuery reportQuery;
+
+  public void processReport(Long reportId) {
+    Report report = reportQuery.getReportById(reportId);
+    report.processed();
+  }
+
+}

--- a/src/main/java/coffeemeet/server/report/implement/ReportQuery.java
+++ b/src/main/java/coffeemeet/server/report/implement/ReportQuery.java
@@ -1,0 +1,24 @@
+package coffeemeet.server.report.implement;
+
+import static coffeemeet.server.report.exception.ReportErrorCode.REPORT_NOT_FOUND;
+
+import coffeemeet.server.common.execption.NotFoundException;
+import coffeemeet.server.report.domain.Report;
+import coffeemeet.server.report.infrastructure.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReportQuery {
+
+  public static final String REPORT_NOT_FOUND_ERROR_MESSAGE = "해당 id(%s)에 매칭되는 신고가 없습니다.";
+  private final ReportRepository reportRepository;
+
+  public Report getReportById(Long reportId) {
+    return reportRepository.findById(reportId)
+        .orElseThrow(() -> new NotFoundException(REPORT_NOT_FOUND,
+            String.format(REPORT_NOT_FOUND_ERROR_MESSAGE, reportId)));
+  }
+
+}

--- a/src/main/java/coffeemeet/server/report/implement/ReportQuery.java
+++ b/src/main/java/coffeemeet/server/report/implement/ReportQuery.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ReportQuery {
 
-  public static final String REPORT_NOT_FOUND_ERROR_MESSAGE = "해당 id(%s)에 매칭되는 신고가 없습니다.";
+  private static final String REPORT_NOT_FOUND_ERROR_MESSAGE = "해당 id(%s)에 매칭되는 신고가 없습니다.";
   private final ReportRepository reportRepository;
 
   public Report getReportById(Long reportId) {

--- a/src/main/java/coffeemeet/server/report/infrastructure/ReportRepository.java
+++ b/src/main/java/coffeemeet/server/report/infrastructure/ReportRepository.java
@@ -1,0 +1,8 @@
+package coffeemeet.server.report.infrastructure;
+
+import coffeemeet.server.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/src/main/java/coffeemeet/server/user/domain/ReportInfo.java
+++ b/src/main/java/coffeemeet/server/user/domain/ReportInfo.java
@@ -1,5 +1,9 @@
 package coffeemeet.server.user.domain;
 
+import static coffeemeet.server.report.exception.ReportErrorCode.EXCEEDED_MAX_REPORT_COUNT;
+
+import coffeemeet.server.common.execption.LimitExceededException;
+import coffeemeet.server.report.domain.ReportPenalty;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
@@ -10,15 +14,29 @@ import lombok.Getter;
 public class ReportInfo {
 
   private static final int REPORT_MIN_COUNT = 0;
+  private static final int REPORT_MAX_COUNT = 5;
 
   @Column(nullable = false)
   private int reportedCount;
 
-  private LocalDateTime sanctionPeriod;
+  private LocalDateTime penaltyExpiration;
 
   public ReportInfo() {
     this.reportedCount = REPORT_MIN_COUNT;
-    this.sanctionPeriod = null;
+    this.penaltyExpiration = null;
+  }
+
+  public void increment() {
+    if (reportedCount >= REPORT_MAX_COUNT) {
+      throw new LimitExceededException(EXCEEDED_MAX_REPORT_COUNT,
+          String.format("최대 신고 누적 횟수를 초과합니다. 신고 누적 횟수(%s)", reportedCount));
+    }
+    this.reportedCount++;
+    int sanctionPeriodByReportCount = ReportPenalty.getSanctionPeriodByReportCount(reportedCount);
+    if (sanctionPeriodByReportCount == -1) {
+      penaltyExpiration = LocalDateTime.MAX;
+    }
+    penaltyExpiration = LocalDateTime.now().plusDays(sanctionPeriodByReportCount);
   }
 
 }

--- a/src/main/java/coffeemeet/server/user/domain/User.java
+++ b/src/main/java/coffeemeet/server/user/domain/User.java
@@ -1,5 +1,8 @@
 package coffeemeet.server.user.domain;
 
+import static coffeemeet.server.user.domain.UserStatus.IDLE;
+import static coffeemeet.server.user.domain.UserStatus.REPORTED;
+
 import coffeemeet.server.chatting.current.domain.ChattingRoom;
 import coffeemeet.server.common.domain.AdvancedBaseEntity;
 import jakarta.persistence.Column;
@@ -65,7 +68,7 @@ public class User extends AdvancedBaseEntity {
     this.profile = profile;
     this.reportInfo = new ReportInfo();
     this.isDeleted = false;
-    this.userStatus = UserStatus.IDLE;
+    this.userStatus = IDLE;
   }
 
   public void updateProfileImageUrl(@NonNull String newProfileImageUrl) {
@@ -121,6 +124,11 @@ public class User extends AdvancedBaseEntity {
   public final int hashCode() {
     return this instanceof HibernateProxy ? ((HibernateProxy) this).getHibernateLazyInitializer()
         .getPersistentClass().hashCode() : getClass().hashCode();
+  }
+
+  public void punished() {
+    this.userStatus = REPORTED;
+    reportInfo.increment();
   }
 
 }

--- a/src/main/java/coffeemeet/server/user/domain/User.java
+++ b/src/main/java/coffeemeet/server/user/domain/User.java
@@ -1,5 +1,7 @@
 package coffeemeet.server.user.domain;
 
+import static coffeemeet.server.user.domain.UserStatus.CHATTING_CONNECTED;
+import static coffeemeet.server.user.domain.UserStatus.CHATTING_UNCONNECTED;
 import static coffeemeet.server.user.domain.UserStatus.IDLE;
 import static coffeemeet.server.user.domain.UserStatus.REPORTED;
 
@@ -88,15 +90,15 @@ public class User extends AdvancedBaseEntity {
   }
 
   public void enterChattingRoom() {
-    this.userStatus = UserStatus.CHATTING_CONNECTED;
+    this.userStatus = CHATTING_CONNECTED;
   }
 
   public void exitChattingRoom() {
-    this.userStatus = UserStatus.CHATTING_UNCONNECTED;
+    this.userStatus = CHATTING_UNCONNECTED;
   }
 
-  public void setIdleState() {
-    this.userStatus = UserStatus.IDLE;
+  public void setIdleStatus() {
+    this.userStatus = IDLE;
   }
 
   @Override

--- a/src/main/java/coffeemeet/server/user/implement/UserQuery.java
+++ b/src/main/java/coffeemeet/server/user/implement/UserQuery.java
@@ -76,6 +76,14 @@ public class UserQuery {
     }
   }
 
+  public NotificationInfo getNotificationInfoByUserId(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new NotFoundException(
+            NOT_EXIST_USER,
+            String.format(NOT_EXIST_USER_MESSAGE, userId))
+        ).getNotificationInfo();
+  }
+
   public List<User> getUsersByRoom(ChattingRoom room) {
     return userRepository.findAllByChattingRoom(room);
   }

--- a/src/main/java/coffeemeet/server/user/service/dto/MyProfileDto.java
+++ b/src/main/java/coffeemeet/server/user/service/dto/MyProfileDto.java
@@ -24,7 +24,7 @@ public sealed interface MyProfileDto permits MyProfileDto.Response {
           user.getProfile().getEmail().getValue(),
           user.getProfile().getProfileImageUrl(),
           user.getReportInfo().getReportedCount(),
-          user.getReportInfo().getSanctionPeriod(),
+          user.getReportInfo().getPenaltyExpiration(),
           department,
           interests
       );

--- a/src/test/java/coffeemeet/server/admin/presentation/AdminControllerTest.java
+++ b/src/test/java/coffeemeet/server/admin/presentation/AdminControllerTest.java
@@ -1,0 +1,182 @@
+package coffeemeet.server.admin.presentation;
+
+import static coffeemeet.server.common.fixture.entity.AdminFixture.adminLoginHTTPRequest;
+import static coffeemeet.server.common.fixture.entity.AdminFixture.certificationApprovalHTTPRequest;
+import static coffeemeet.server.common.fixture.entity.AdminFixture.certificationRejectionHTTPRequest;
+import static coffeemeet.server.common.fixture.entity.AdminFixture.reportApprovalHTTPRequest;
+import static coffeemeet.server.common.fixture.entity.AdminFixture.reportRejectionHTTPRequest;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import coffeemeet.server.admin.service.AdminService;
+import coffeemeet.server.common.config.ControllerTestConfig;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebMvcTest(AdminController.class)
+class AdminControllerTest extends ControllerTestConfig {
+
+  @MockBean
+  private AdminService adminService;
+
+  private static final String SESSION = "session";
+
+  @Test
+  @DisplayName("관리자 로그인을 할 수 있다.")
+  void loginTest() throws Exception {
+    // given
+    String loginRequest = objectMapper.writeValueAsString(adminLoginHTTPRequest());
+
+    // when, then
+    mockMvc.perform(post("/api/v1/admin/login")
+            .contentType(APPLICATION_JSON)
+            .content(loginRequest))
+        .andDo(document("admin-login",
+            resourceDetails().tag("관리자").description("관리자 로그인")
+                .requestSchema(Schema.schema("AdminLoginHTTP.Request")),
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestFields(
+                fieldWithPath("id").description("관리자 ID"),
+                fieldWithPath("password").description("관리자 비밀번호")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("관리자 로그아웃 할 수 있다.")
+  void name() throws Exception {
+    // given, when, then
+    mockMvc.perform(post("/api/v1/admin/logout")
+            .header("JSESSION", SESSION)
+        )
+        .andDo(document("admin-logout",
+            resourceDetails().tag("관리자").description("관리자 로그아웃")
+                .requestSchema(Schema.schema("CertificationApprovalHTTP.Request")),
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestHeaders(
+                headerWithName("JSESSION").description("세션")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("인증 허가 요청을 처리할 수 있다.")
+  void approveCertification() throws Exception {
+    // given
+    String approvalRequest = objectMapper.writeValueAsString(certificationApprovalHTTPRequest());
+    // when, then
+    mockMvc.perform(patch("/api/v1/admin/certification/approval")
+            .header("JSESSION", SESSION)
+            .sessionAttr("adminId", "admin")
+            .contentType(APPLICATION_JSON)
+            .content(approvalRequest))
+        .andDo(document("certification-approval",
+            resourceDetails().tag("관리자").description("관리자 인증 허가")
+                .requestSchema(Schema.schema("CertificationApprovalHTTP.Request")),
+            requestHeaders(
+                headerWithName("JSESSION").description("세션")
+            ),
+            requestFields(
+                fieldWithPath("userId").description("승인할 사용자의 ID")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("인증 반려 요청을 처리할 수 있다.")
+  void rejectCertification() throws Exception {
+    // given
+    String rejectionRequest = objectMapper.writeValueAsString(certificationRejectionHTTPRequest());
+
+    // when, then
+    mockMvc.perform(patch("/api/v1/admin/certification/rejection")
+            .header("JSESSION", SESSION)
+            .sessionAttr("adminId", "admin")
+            .contentType(APPLICATION_JSON)
+            .content(rejectionRequest))
+        .andDo(document("certification-rejection",
+            resourceDetails().tag("관리자").description("관리자 인증 반려")
+                .requestSchema(Schema.schema("CertificationRejectionHTTP.Request")),
+            requestHeaders(
+                headerWithName("JSESSION").description("세션")
+            ),
+            requestFields(
+                fieldWithPath("userId").description("반려할 사용자의 ID")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+
+  @Test
+  @DisplayName("신고 승인 요청을 처리할 수 있다.")
+  void assignReportPenalty() throws Exception {
+    // given
+    String approvalRequestJson = objectMapper.writeValueAsString(reportApprovalHTTPRequest());
+
+    // when, then
+    mockMvc.perform(patch("/api/v1/admin/report/punishment")
+            .header("JSESSION", SESSION)
+            .sessionAttr("adminId", "admin")
+            .contentType(APPLICATION_JSON)
+            .content(approvalRequestJson))
+        .andDo(document("report-punishment",
+            resourceDetails().tag("관리자").description("관리자 신고 승인")
+                .requestSchema(Schema.schema("ReportApprovalHTTP.Request")),
+            requestHeaders(
+                headerWithName("JSESSION").description("세션")
+            ),
+            requestFields(
+                fieldWithPath("reportId").description("승인할 신고의 ID"),
+                fieldWithPath("userId").description("신고된 사용자의 ID")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+
+  @Test
+  @DisplayName("신고 거부 요청을 처리할 수 있다.")
+  void dismissReport() throws Exception {
+    // given
+    String rejectionRequestJson = objectMapper.writeValueAsString(reportRejectionHTTPRequest());
+
+    // when, then
+    mockMvc.perform(patch("/api/v1/admin/report/rejection")
+            .header("JSESSION", SESSION)
+            .sessionAttr("adminId", "admin")
+            .contentType(APPLICATION_JSON)
+            .content(rejectionRequestJson))
+        .andDo(document("report-rejection",
+            resourceDetails().tag("관리자").description("관리자 신고 거부")
+                .requestSchema(Schema.schema("ReportRejectionHTTP.Request")),
+            requestHeaders(
+                headerWithName("JSESSION").description("세션")
+            ),
+            requestFields(
+                fieldWithPath("reportId").description("거부할 신고의 ID")
+            )
+        ))
+        .andExpect(status().isOk());
+  }
+
+}

--- a/src/test/java/coffeemeet/server/admin/service/AdminServiceTest.java
+++ b/src/test/java/coffeemeet/server/admin/service/AdminServiceTest.java
@@ -1,0 +1,116 @@
+package coffeemeet.server.admin.service;
+
+import static coffeemeet.server.user.domain.UserStatus.MATCHING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+
+import coffeemeet.server.certification.implement.CertificationCommand;
+import coffeemeet.server.certification.implement.CertificationQuery;
+import coffeemeet.server.common.implement.FCMNotificationSender;
+import coffeemeet.server.matching.implement.MatchingQueueCommand;
+import coffeemeet.server.report.implement.ReportCommand;
+import coffeemeet.server.user.domain.User;
+import coffeemeet.server.user.implement.UserQuery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+  @InjectMocks
+  private AdminService adminService;
+
+  @Mock
+  private CertificationCommand certificationCommand;
+
+  @Mock
+  private UserQuery userQuery;
+
+  @Mock
+  private FCMNotificationSender fcmNotificationSender;
+
+  @Mock
+  private ReportCommand reportCommand;
+
+  @Mock
+  private MatchingQueueCommand matchingQueueCommand;
+
+  @Mock
+  private CertificationQuery certificationQuery;
+
+
+  @Test
+  @DisplayName("인증 수락 처리를 할 수 있다.")
+  void approveCertificationTest() {
+    // given
+    Long userId = 1L;
+
+    // when
+    adminService.approveCertification(userId);
+
+    // then
+    then(certificationCommand).should(only()).certificated(userId);
+    then(userQuery).should(only()).getNotificationInfoByUserId(userId);
+    then(fcmNotificationSender).should(only()).sendNotification(any(), any());
+  }
+
+  @Test
+  @DisplayName("인증 거절 처리를 할 수 있다.")
+  void rejectCertificationTest() {
+    // given
+    Long userId = 1L;
+
+    // when
+    adminService.rejectCertification(userId);
+
+    // then
+    then(certificationCommand).should(only()).deleteUserCertification(userId);
+    then(userQuery).should(only()).getNotificationInfoByUserId(userId);
+    then(fcmNotificationSender).should(only()).sendNotification(any(), any());
+  }
+
+  @Test
+  @DisplayName("신고 패널티를 부과하고 알림을 보낼 수 있다.")
+  void punishUserTest() {
+    // given
+    Long userId = 1L;
+    Long reportId = 1L;
+    User user = mock(User.class);
+    String companyName = "Company";
+
+    willDoNothing().given(user).punished();
+    given(user.getUserStatus()).willReturn(MATCHING);
+    given(userQuery.getUserById(userId)).willReturn(user);
+    given(certificationQuery.getCompanyNameByUserId(userId)).willReturn(companyName);
+
+    // when
+    adminService.punishUser(reportId, userId);
+
+    // then
+    then(matchingQueueCommand).should(only()).deleteUserByUserId(companyName, userId);
+    then(reportCommand).should(only()).processReport(reportId);
+    then(fcmNotificationSender).should(only()).sendNotification(any(), any());
+  }
+
+  @Test
+  @DisplayName("신고 반려 처리를 할 수 있다.")
+  void dismissReportTest() {
+    // given
+    Long reportId = 1L;
+
+    // when
+    adminService.dismissReport(reportId);
+
+    // then
+    then(reportCommand).should(only()).processReport(reportId);
+  }
+
+}

--- a/src/test/java/coffeemeet/server/admin/service/AdminServiceTest.java
+++ b/src/test/java/coffeemeet/server/admin/service/AdminServiceTest.java
@@ -78,7 +78,7 @@ class AdminServiceTest {
   }
 
   @Test
-  @DisplayName("신고 패널티를 부과하고 알림을 보낼 수 있다.")
+  @DisplayName("매칭 중인 유저를 매칭 큐에서 제외하고 신고 패널티를 부과하고 알림을 보낼 수 있다.")
   void punishUserTest() {
     // given
     Long userId = 1L;

--- a/src/test/java/coffeemeet/server/certification/service/cq/CertificationCommandTest.java
+++ b/src/test/java/coffeemeet/server/certification/service/cq/CertificationCommandTest.java
@@ -6,6 +6,7 @@ import static coffeemeet.server.common.fixture.entity.CertificationFixture.compa
 import static coffeemeet.server.common.fixture.entity.CertificationFixture.companyName;
 import static coffeemeet.server.common.fixture.entity.CertificationFixture.department;
 import static coffeemeet.server.common.fixture.entity.UserFixture.user;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -16,6 +17,7 @@ import coffeemeet.server.certification.domain.Certification;
 import coffeemeet.server.certification.domain.CompanyEmail;
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.certification.implement.CertificationCommand;
+import coffeemeet.server.certification.implement.CertificationQuery;
 import coffeemeet.server.certification.infrastructure.CertificationRepository;
 import coffeemeet.server.common.execption.InvalidInputException;
 import coffeemeet.server.user.domain.User;
@@ -37,6 +39,8 @@ class CertificationCommandTest {
   private CertificationCommand certificationCommand;
   @Mock
   private CertificationRepository certificationRepository;
+  @Mock
+  private CertificationQuery certificationQuery;
 
   @Test
   @DisplayName("새로운 Certification 객체를 저장할 수 있다.")
@@ -84,6 +88,34 @@ class CertificationCommandTest {
 
     // then
     then(consumer).should(only()).accept(certification);
+  }
+
+  @Test
+  @DisplayName("사용자 인증을 완료시킬 수 있다.")
+  void certificatedTest() {
+    // given
+    Certification certification = certification();
+    Long userId = certification.getUser().getId();
+    given(certificationQuery.getCertificationByUserId(userId)).willReturn(certification);
+
+    // when
+    certificationCommand.certificated(userId);
+
+    // then
+    assertThat(certification.isCertificated()).isTrue();
+  }
+
+  @Test
+  @DisplayName("인증 정보를 삭제할 수 있다.")
+  void deleteUserCertification() {
+    // given
+    Long userId = 1L;
+
+    // when
+    certificationCommand.deleteUserCertification(userId);
+
+    // then
+    then(certificationRepository).should(only()).deleteById(userId);
   }
 
 }

--- a/src/test/java/coffeemeet/server/certification/service/cq/CertificationQueryTest.java
+++ b/src/test/java/coffeemeet/server/certification/service/cq/CertificationQueryTest.java
@@ -42,4 +42,21 @@ class CertificationQueryTest {
     assertThat(foundCertification).isEqualTo(certification);
   }
 
+  @Test
+  @DisplayName("유저 아이디로 회사 이름을 가져올 수 있다.")
+  void getCompanyNameByUserIdTest() {
+    // given
+    User user = user();
+    Long userId = user.getId();
+    Certification certification = certification(user);
+
+    given(certificationRepository.findByUserId(userId)).willReturn(Optional.of(certification));
+
+    // when
+    String companyName = certificationQuery.getCompanyNameByUserId(userId);
+
+    // then
+    assertThat(companyName).isEqualTo(certification.getCompanyName());
+  }
+
 }

--- a/src/test/java/coffeemeet/server/common/fixture/entity/AdminFixture.java
+++ b/src/test/java/coffeemeet/server/common/fixture/entity/AdminFixture.java
@@ -1,6 +1,6 @@
 package coffeemeet.server.common.fixture.entity;
 
-import coffeemeet.server.admin.presentation.AdminLoginHTTP;
+import coffeemeet.server.admin.presentation.dto.AdminLoginHTTP;
 import coffeemeet.server.admin.presentation.dto.CertificationApprovalHTTP;
 import coffeemeet.server.admin.presentation.dto.CertificationRejectionHTTP;
 import coffeemeet.server.admin.presentation.dto.ReportApprovalHTTP;

--- a/src/test/java/coffeemeet/server/common/fixture/entity/AdminFixture.java
+++ b/src/test/java/coffeemeet/server/common/fixture/entity/AdminFixture.java
@@ -1,0 +1,33 @@
+package coffeemeet.server.common.fixture.entity;
+
+import coffeemeet.server.admin.presentation.AdminLoginHTTP;
+import coffeemeet.server.admin.presentation.dto.CertificationApprovalHTTP;
+import coffeemeet.server.admin.presentation.dto.CertificationRejectionHTTP;
+import coffeemeet.server.admin.presentation.dto.ReportApprovalHTTP;
+import coffeemeet.server.admin.presentation.dto.ReportRejectionHTTP;
+import org.instancio.Instancio;
+
+public class AdminFixture {
+
+
+  public static AdminLoginHTTP.Request adminLoginHTTPRequest() {
+    return Instancio.of(AdminLoginHTTP.Request.class).create();
+  }
+
+  public static CertificationApprovalHTTP.Request certificationApprovalHTTPRequest() {
+    return Instancio.of(CertificationApprovalHTTP.Request.class).create();
+  }
+
+  public static CertificationRejectionHTTP.Request certificationRejectionHTTPRequest() {
+    return Instancio.of(CertificationRejectionHTTP.Request.class).create();
+  }
+
+  public static  ReportApprovalHTTP.Request reportApprovalHTTPRequest() {
+    return Instancio.of(ReportApprovalHTTP.Request.class).create();
+  }
+
+  public static ReportRejectionHTTP.Request reportRejectionHTTPRequest() {
+    return Instancio.of(ReportRejectionHTTP.Request.class).create();
+  }
+
+}


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #114 #115 

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- [x] 관리자 인증 허가 / 반려
- [x]  관리자 신고 승인 / 거부

## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->

아래는 관리자가 로그인을 한 후 다음 페이지로 넘어간 뒤에 화면입니다. 로그인이 성공적으로 이루어지면, JSESSION이 발급됩니다.

![스크린샷 2023-11-20 오전 2 03 10](https://github.com/coffee-meet/backend/assets/70051888/c7de1540-9928-4e36-be94-2d542d8efe32)

아래는 로그인을 하지 않고 요청을 보냈을 때 화면입니다. 401 에러가 발생합니다.

<img width="982" alt="스크린샷 2023-11-20 오전 2 23 11" src="https://github.com/coffee-meet/backend/assets/70051888/d05ddfa5-c47c-409f-b564-9b889dff8f79">

아래는 로그인을 한 뒤에, 요청을 보냈을 때 화면입니다. 404 에러가 발생하는데, 실제 Report가 DB에 없어서 나는 에러입니다.

<img width="1014" alt="스크린샷 2023-11-20 오전 2 24 16" src="https://github.com/coffee-meet/backend/assets/70051888/87bae152-461c-436b-83fd-d83e336623f9">

