### PR TITLE
refactor: 모든 DTO final class 로 변경

### DIFF
--- a/src/main/java/coffeemeet/server/admin/presentation/dto/AdminLoginHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/AdminLoginHTTP.java
@@ -1,15 +1,19 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotBlank;
+import lombok.NoArgsConstructor;
 
-public sealed interface AdminLoginHTTP permits AdminLoginHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class AdminLoginHTTP {
 
-  record Request(
+  public record Request(
       @NotBlank
       String id,
       @NotBlank
       String password
-  ) implements AdminLoginHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationApprovalHTTP.java
@@ -1,13 +1,17 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface CertificationApprovalHTTP permits CertificationApprovalHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class CertificationApprovalHTTP {
 
-  record Request(
+  public record Request(
       @NotNull
       Long userId
-  ) implements CertificationApprovalHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/CertificationRejectionHTTP.java
@@ -1,13 +1,17 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface CertificationRejectionHTTP permits CertificationRejectionHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class CertificationRejectionHTTP {
 
-  record Request(
+  public record Request(
       @NotNull
       Long userId
-  ) implements CertificationRejectionHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportApprovalHTTP.java
@@ -1,15 +1,19 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface ReportApprovalHTTP permits ReportApprovalHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class ReportApprovalHTTP {
 
-  record Request(
+  public record Request(
       @NotNull
       Long reportId,
       @NotNull
       Long userId
-  ) implements ReportApprovalHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
+++ b/src/main/java/coffeemeet/server/admin/presentation/dto/ReportRejectionHTTP.java
@@ -1,13 +1,17 @@
 package coffeemeet.server.admin.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface ReportRejectionHTTP permits ReportRejectionHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class ReportRejectionHTTP {
 
-  record Request(
+  public record Request(
       @NotNull
       Long reportId
-  ) implements ReportRejectionHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/certification/presentation/dto/EmailHTTP.java
+++ b/src/main/java/coffeemeet/server/certification/presentation/dto/EmailHTTP.java
@@ -1,14 +1,17 @@
 package coffeemeet.server.certification.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface EmailHTTP permits EmailHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class EmailHTTP {
 
-  record Request(
-      @Email @NotNull
-      String companyEmail
-  ) implements EmailHTTP {
+  public record Request(
+      @Email @NotNull String companyEmail
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/certification/presentation/dto/VerificationCodeHTTP.java
+++ b/src/main/java/coffeemeet/server/certification/presentation/dto/VerificationCodeHTTP.java
@@ -1,14 +1,18 @@
 package coffeemeet.server.certification.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
-public sealed interface VerificationCodeHTTP permits VerificationCodeHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class VerificationCodeHTTP {
 
-  record Request(
+  public record Request(
       @NotNull @Length(min = 6, max = 6)
       String verificationCode
-  ) implements VerificationCodeHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatStomp.java
+++ b/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatStomp.java
@@ -1,29 +1,33 @@
 package coffeemeet.server.chatting.current.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.chatting.current.service.dto.ChattingDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
-public sealed interface ChatStomp permits ChatStomp.Request, ChatStomp.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class ChatStomp {
 
-  record Request(
+  public record Request(
       @NotNull
       Long roomId,
       @NotBlank
       String content
-  ) implements ChatStomp {
+  ) {
 
   }
 
-  record Response(
+  public record Response(
       Long userId,
       Long messageId,
       String nickname,
       String content,
       String profileImageUrl,
       LocalDateTime createdAt
-  ) implements ChatStomp {
+  ) {
 
     public static ChatStomp.Response from(ChattingDto.Response response) {
       return new ChatStomp.Response(

--- a/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatsHTTP.java
+++ b/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatsHTTP.java
@@ -1,10 +1,14 @@
 package coffeemeet.server.chatting.current.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.chatting.current.service.dto.ChattingDto;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface ChatsHTTP permits ChatsHTTP.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class ChatsHTTP {
 
   record Chat(
       Long userId,
@@ -28,7 +32,7 @@ public sealed interface ChatsHTTP permits ChatsHTTP.Response {
 
   }
 
-  record Response(List<Chat> chats) implements ChatsHTTP {
+  public record Response(List<Chat> chats) {
 
     public static Response from(List<ChattingDto.Response> responses) {
       List<Chat> chatList = responses.stream()

--- a/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatsHTTP.java
+++ b/src/main/java/coffeemeet/server/chatting/current/presentation/dto/ChatsHTTP.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class ChatsHTTP {
 
-  record Chat(
+  public record Chat(
       Long userId,
       Long messageId,
       String nickname,

--- a/src/main/java/coffeemeet/server/chatting/current/service/dto/ChattingDto.java
+++ b/src/main/java/coffeemeet/server/chatting/current/service/dto/ChattingDto.java
@@ -1,19 +1,23 @@
 package coffeemeet.server.chatting.current.service.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.chatting.current.domain.ChattingMessage;
 import coffeemeet.server.user.domain.User;
 import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
-public sealed interface ChattingDto permits ChattingDto.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class ChattingDto {
 
-  record Response(
+  public record Response(
       Long userId,
       Long messageId,
       String nickname,
       String content,
       String profileImageUrl,
       LocalDateTime createdAt
-  ) implements ChattingDto {
+  ) {
 
     public static Response of(User user, ChattingMessage chattingMessage) {
       return new Response(

--- a/src/main/java/coffeemeet/server/user/presentation/dto/LoginDetailsHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/LoginDetailsHTTP.java
@@ -1,13 +1,17 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.service.dto.LoginDetailsDto;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface LoginDetailsHTTP permits LoginDetailsHTTP.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class LoginDetailsHTTP {
 
-  record Response(
+  public record Response(
       String accessToken,
       String refreshToken,
       String nickname,
@@ -15,7 +19,7 @@ public sealed interface LoginDetailsHTTP permits LoginDetailsHTTP.Response {
       String companyName,
       Department department,
       List<Keyword> interests
-  ) implements LoginDetailsHTTP {
+  ) {
 
     public static Response of(LoginDetailsDto.Response response) {
       return new Response(

--- a/src/main/java/coffeemeet/server/user/presentation/dto/MyProfileHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/MyProfileHTTP.java
@@ -1,14 +1,18 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.service.dto.MyProfileDto;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface MyProfileHTTP permits MyProfileHTTP.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class MyProfileHTTP {
 
-  record Response(
+  public record Response(
       String nickname,
       String email,
       String profileImageUrl,
@@ -16,7 +20,7 @@ public sealed interface MyProfileHTTP permits MyProfileHTTP.Response {
       LocalDateTime sanctionPeriod,
       Department department,
       List<Keyword> interests
-  ) implements MyProfileHTTP {
+  ) {
 
     public static Response of(MyProfileDto.Response response) {
       return new Response(

--- a/src/main/java/coffeemeet/server/user/presentation/dto/NotificationTokenHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/NotificationTokenHTTP.java
@@ -1,14 +1,18 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
 
-public sealed interface NotificationTokenHTTP permits NotificationTokenHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class NotificationTokenHTTP {
 
-  record Request(
+  public record Request(
       @Email @NotNull
       String token
-  ) implements NotificationTokenHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/user/presentation/dto/SignupHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/SignupHTTP.java
@@ -1,15 +1,18 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.domain.OAuthProvider;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
+@NoArgsConstructor(access = PRIVATE)
+public final class SignupHTTP {
 
-public sealed interface SignupHTTP permits SignupHTTP.Request {
-
-  record Request(
+  public record Request(
       @NotBlank
       String nickname,
       @NotNull
@@ -18,7 +21,7 @@ public sealed interface SignupHTTP permits SignupHTTP.Request {
       String authCode,
       @NonNull
       OAuthProvider oAuthProvider
-  ) implements SignupHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/user/presentation/dto/UpdateProfileHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/UpdateProfileHTTP.java
@@ -1,15 +1,19 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.user.domain.Keyword;
 import jakarta.validation.constraints.Size;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface UpdateProfileHTTP permits UpdateProfileHTTP.Request {
+@NoArgsConstructor(access = PRIVATE)
+public final class UpdateProfileHTTP {
 
-  record Request(
+  public record Request(
       String nickname,
       @Size(min = 1, max = 3) List<Keyword> interests
-  ) implements UpdateProfileHTTP {
+  ) {
 
   }
 

--- a/src/main/java/coffeemeet/server/user/presentation/dto/UserProfileHTTP.java
+++ b/src/main/java/coffeemeet/server/user/presentation/dto/UserProfileHTTP.java
@@ -1,18 +1,22 @@
 package coffeemeet.server.user.presentation.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.service.dto.UserProfileDto;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface UserProfileHTTP permits UserProfileHTTP.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class UserProfileHTTP {
 
-  record Response(
+  public record Response(
       String nickname,
       String profileImageUrl,
       Department department,
       List<Keyword> interests
-  ) implements UserProfileHTTP {
+  ) {
 
     public static Response of(UserProfileDto.Response response) {
       return new Response(

--- a/src/main/java/coffeemeet/server/user/service/dto/LoginDetailsDto.java
+++ b/src/main/java/coffeemeet/server/user/service/dto/LoginDetailsDto.java
@@ -1,15 +1,19 @@
 package coffeemeet.server.user.service.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.auth.domain.AuthTokens;
 import coffeemeet.server.certification.domain.Certification;
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.domain.User;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface LoginDetailsDto permits LoginDetailsDto.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class LoginDetailsDto {
 
-  record Response(
+  public record Response(
       String accessToken,
       String refreshToken,
       String nickname,
@@ -17,7 +21,7 @@ public sealed interface LoginDetailsDto permits LoginDetailsDto.Response {
       String companyName,
       Department department,
       List<Keyword> interests
-  ) implements LoginDetailsDto {
+  ) {
 
     public static Response of(User user, List<Keyword> interests, Certification certification,
         AuthTokens authTokens) {

--- a/src/main/java/coffeemeet/server/user/service/dto/MyProfileDto.java
+++ b/src/main/java/coffeemeet/server/user/service/dto/MyProfileDto.java
@@ -1,14 +1,18 @@
 package coffeemeet.server.user.service.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface MyProfileDto permits MyProfileDto.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class MyProfileDto {
 
-  record Response(
+  public record Response(
       String nickname,
       String email,
       String profileImageUrl,
@@ -16,7 +20,7 @@ public sealed interface MyProfileDto permits MyProfileDto.Response {
       LocalDateTime sanctionPeriod,
       Department department,
       List<Keyword> interests
-  ) implements MyProfileDto {
+  ) {
 
     public static Response of(User user, List<Keyword> interests, Department department) {
       return new Response(

--- a/src/main/java/coffeemeet/server/user/service/dto/UserProfileDto.java
+++ b/src/main/java/coffeemeet/server/user/service/dto/UserProfileDto.java
@@ -1,18 +1,22 @@
 package coffeemeet.server.user.service.dto;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import coffeemeet.server.certification.domain.Department;
 import coffeemeet.server.user.domain.Keyword;
 import coffeemeet.server.user.domain.User;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
-public sealed interface UserProfileDto permits UserProfileDto.Response {
+@NoArgsConstructor(access = PRIVATE)
+public final class UserProfileDto {
 
-  record Response(
+  public record Response(
       String nickname,
       String profileImageUrl,
       Department department,
       List<Keyword> interests
-  ) implements UserProfileDto {
+  ) {
 
     public static Response of(User user, Department department,
         List<Keyword> interests) {


### PR DESCRIPTION
## 이슈번호
<!-- - close 뒤에 이슈 달아주기 -->
close: #123

## 작업 내용 설명
<!-- 스크린샷 및 작업내용을 적어주세요 -->
- [x] sealed class 를 모두 final class로 변경

## 리뷰어에게 한마디
<!-- 리뷰어들이 참고해야 하는 사항을 적어주세요 -->

기존에 전파 했던 내용 다시 문서로 남깁니다!

최초에는 sealed interface를 사용하여 웹 통신 객체를 구현했었습니다. 이 방법이 효율적이라고 생각하셨지만, 실제로 구현해보니 몇 가지 문제점이 드러났습니다.

sealed interface에서 다형성이 적용되는 문제는 명백한 단점이고, 위 방법에서는 외부 sealed interface(웹 통신 객체)가 인터페이스의 의미 자체를 갖고 있지 않은데 사용한 것이 걸렸습니다.

당시에는 sealed interface는 구현되는 객체를 알고 있기 때문에 내부클래스들을 `enum`객체 처럼 사용할 수 있을 거라고 기대했고, 단점이 상쇄된다고 생각했지만, 최악의 경우에 문제가 발생할 여지가 있습니다.

이에 따라 sealed interface를 final class로 전환하기로 결정했습니다.

final class는 기존의 sealed interface가 가진 이점은 유지하면서 그 단점들을 상쇄하는 효과가 있다고 생각합니다.

첫째, Request와 Response 클래스를 별도로 만들 필요 없이 하나의 클래스에서 관리할 수 있게 되어 패키지 구조가 간결해졌습니다.

둘째, 한 클래스 내에서 Request와 Response를 함께 볼 수 있게 되어 응집도와 가독성이 향상되었습니다.
